### PR TITLE
Send using json

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install using pip...
 ```commandline
 pip install django-outlook-email-backend
 ```
-Add  `'OUTLOOK_CREDENTIALS'` in `'settings.py'`  
+Add  `'OUTLOOK_CREDENTIALS'` in `settings.py`  
 ```python
 OUTLOOK_CREDENTIALS = {
     'OUTLOOK_CLIENT_ID': "XXXXX",
@@ -19,8 +19,13 @@ OUTLOOK_CREDENTIALS = {
 }
 ```
 
-Add  `'EMAIL_BACKEND'` in `'settings.py'`  
+Add  `'EMAIL_BACKEND'` in `settings.py`  
 
 ```python
 EMAIL_BACKEND = "django_outlook_email.django_outlook_email_backend.OutlookEmailBackend"
 ``` 
+
+if you want to use json instead of mime the add the following line in in `settings.py`
+```python
+OUTLOOK_CREDENTIALS["OUTLOOK_SEND_FORMAT"] = "json"
+```

--- a/django_outlook_email/django_outlook_email_backend.py
+++ b/django_outlook_email/django_outlook_email_backend.py
@@ -17,7 +17,7 @@ class OutlookEmailBackend(BaseEmailBackend):
     client_id = settings.OUTLOOK_CREDENTIALS["OUTLOOK_CLIENT_ID"]
     client_secret = settings.OUTLOOK_CREDENTIALS["OUTLOOK_CLIENT_SECRET"]
     tenant_id = settings.OUTLOOK_CREDENTIALS["OUTLOOK_TENANT_ID"]
-    send_format = settings.OUTLOOK_CREDENTIALS["OUTLOOK_SEND_FORMAT"]
+    send_format = settings.OUTLOOK_CREDENTIALS.get("OUTLOOK_SEND_FORMAT")
 
 
     def send_messages(self, email_messages):

--- a/django_outlook_email/exceptions/microsoft_graph_exceptions.py
+++ b/django_outlook_email/exceptions/microsoft_graph_exceptions.py
@@ -5,3 +5,8 @@ class MicrosoftGraphException(Exception):
         self.message = message
         super().__init__("status_code: {} ,message: {}".format(status_code, message))
 
+class JsonSenderException(Exception):
+    """Json Sender error has ocurred."""
+    def __init__(self, status_code, message):
+        self.message = message
+        super().__init__(message)

--- a/django_outlook_email/senders/base_sender.py
+++ b/django_outlook_email/senders/base_sender.py
@@ -1,0 +1,4 @@
+class BaseSender:
+    def __init__(self, access_token, fail_silently=False):
+        self.access_token = access_token
+        self.fail_silently = fail_silently

--- a/django_outlook_email/senders/content_types.py
+++ b/django_outlook_email/senders/content_types.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+class ContentType(Enum):
+    TEXT_PLAIN = "text/plain"
+    TEXT_HTML = "text/html"
+
+class MicrosoftContentType(Enum):
+    TEXT_PLAIN = "Text"
+    TEXT_HTML = "HTML"
+
+    @classmethod
+    def django_to_microsoft(cls, content_type):
+        content_type_mapping = {
+            ContentType.TEXT_PLAIN.value: cls.TEXT_PLAIN.value,
+            ContentType.TEXT_HTML.value: cls.TEXT_HTML.value,
+        }
+        try:
+            return content_type_mapping[content_type]
+        except KeyError:
+            raise ValueError(f"Unsupported content type: {content_type}")

--- a/django_outlook_email/senders/json_sender.py
+++ b/django_outlook_email/senders/json_sender.py
@@ -1,0 +1,98 @@
+import base64
+import mimetypes
+from email.mime.base import MIMEBase
+
+from django.conf import settings
+from django_outlook_email.exceptions.microsoft_graph_exceptions import JsonSenderException
+from django_outlook_email.senders.base_sender import BaseSender
+from django.core.mail.message import sanitize_address
+import requests
+
+class JsonSender(BaseSender):
+
+    def send(self, email_message):
+        if not email_message.recipients():
+            return False
+
+        encoding = email_message.encoding or settings.DEFAULT_CHARSET
+        from_email = sanitize_address(email_message.from_email, encoding)
+        recipients = [
+            {"emailAddress": {"address": sanitize_address(addr, encoding)}} for addr in email_message.recipients()
+        ]
+
+        content, content_type = self._get_content_and_content_type(email_message)
+
+        data = {
+            "message": {
+                "body": {
+                    "content": content,
+                    "contentType": "HTML"  # text/html #plain
+                },
+                "subject": email_message.subject,
+                "toRecipients": recipients,
+                "hasAttachments": False,
+            }
+        }
+
+        attachments = self._get_attachments(email_message)
+        if attachments:
+            data["message"]["hasAttachments"] = True
+            data["message"]["attachments"] = attachments
+        print(data)
+        response = requests.post(
+            "https://graph.microsoft.com/v1.0/users/" + from_email + "/sendMail",
+            json=data,
+
+            headers={"Authorization": "Bearer " + self.access_token},
+        )
+
+        return True
+
+    def _get_content_and_content_type(self, email_message):
+        alternatives = self._get_alternatives(email_message)
+        if alternatives:
+            content = email_message.alternatives[0][0]
+            content_type = email_message.alternatives[0][1]
+        else:
+            content = email_message.body
+            content_type = email_message.content_subtype
+
+        return content, content_type
+
+    def _get_alternatives(self, email_message):
+        html_alternatives = []
+        text_plain_alternatives = []
+        for alternative in email_message.alternatives:
+            if alternative[1] == "text/plain":
+                text_plain_alternatives.append(alternative[0])
+            elif alternative[1] == "text/html":
+                html_alternatives.append(alternative[0])
+            else:
+                raise JsonSenderException("Only text/plain and text/html alternatives are supported")
+
+        if len(text_plain_alternatives) > 1:
+            raise JsonSenderException("Only one text/plain alternative is supported")
+        if len(html_alternatives) > 1:
+            raise JsonSenderException("Only one text/html alternative is supported")
+
+        return html_alternatives if html_alternatives else text_plain_alternatives
+
+    def _get_attachments(self, email_message):
+        attachments = []
+        for attachment in email_message.attachments:
+            if isinstance(attachment, MIMEBase):
+                attachments.append({
+                    "@odata.type": "#microsoft.graph.fileAttachment",
+                    "name": attachment.get_filename(),
+                    "contentBytes":  attachment.get_payload(decode=True),
+                    "contentType": attachment.get_content_type(),
+                })
+            else:
+                attachments.append({
+                    "@odata.type": "#microsoft.graph.fileAttachment",
+                    "name": attachment[0],
+                    "contentBytes": base64.b64encode(attachment[1]).decode('utf-8'),
+                    "contentType":  attachment[2],
+                })
+        return attachments
+

--- a/django_outlook_email/senders/mime_sender.py
+++ b/django_outlook_email/senders/mime_sender.py
@@ -1,0 +1,39 @@
+import base64
+
+import msal
+import requests
+from django.core.mail.message import sanitize_address
+from django.conf import settings
+from django.core.mail.backends.base import BaseEmailBackend
+
+from django_outlook_email.exceptions.microsoft_graph_exceptions import MicrosoftGraphException
+from django_outlook_email.senders.base_sender import BaseSender
+
+
+class MimeSender(BaseSender):
+    def send(self, email_message):
+        if not email_message.recipients():
+            return False
+        encoding = email_message.encoding or settings.DEFAULT_CHARSET
+        from_email = sanitize_address(email_message.from_email, encoding)
+
+        message = email_message.message()
+
+        try:
+            response = requests.post(
+                "https://graph.microsoft.com/v1.0/users/" + from_email + "/sendMail",
+                data=base64.b64encode(message.as_bytes(linesep="\r\n")),
+
+                headers={"Authorization": "Bearer " + self.access_token, "Content-type": "text/plain"}
+            )
+        except requests.exceptions.RequestException:
+            if not self.fail_silently:
+                raise
+            return False
+
+        if response.status_code == 202:
+            return True
+        else:
+            if not self.fail_silently:
+                raise MicrosoftGraphException(response.status_code, response.content)
+            return False

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='django_outlook_email-backend',
-    version='1.0.1',
+    version='1.1.0',
     description='Ouauth2 outlook email backend for Django',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
@@ -20,6 +20,6 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     url='https://github.com/enley-es/django-outlook-email-backend',
-    packages=["django_outlook_email","django_outlook_email.exceptions"],
+    packages=["django_outlook_email","django_outlook_email.exceptions", "django_outlook_email.senders"],
     install_requires = ['requests~=2.25', 'msal==1.*']
 )


### PR DESCRIPTION
Closes #1 
You can add the `json` send type in setings.py and you can send emails using json instead of mime types