### PR TITLE
Add retry on error to retry on unexpected api errors from microsoft

### DIFF
--- a/django_outlook_email/senders/microsoft_requests/microsoft_requests.py
+++ b/django_outlook_email/senders/microsoft_requests/microsoft_requests.py
@@ -4,6 +4,7 @@ from django_outlook_email.exceptions.microsoft_graph_exceptions import Microsoft
 import requests
 
 from django_outlook_email.senders.encoders.lazy_encoders import LazyEncoder
+from requests.adapters import HTTPAdapter, Retry
 
 
 class MicrosoftRequests:
@@ -15,7 +16,12 @@ class MicrosoftRequests:
     def post(self, endpoint, data):
         data = json.dumps(data, cls=LazyEncoder)
         try:
-            response = requests.post(
+
+            session = requests.Session()
+            retries = Retry(total=5, backoff_factor=1, status_forcelist=[500])
+            session.mount('https://', HTTPAdapter(max_retries=retries))
+
+            response = session.post(
                 "https://graph.microsoft.com/v1.0/users/" + self.from_email + "/" + endpoint,
                 data=data,
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='django_outlook_email-backend',
-    version='1.1.10',
+    version='1.1.11',
     description='Ouauth2 outlook email backend for Django',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Is to partially fix this issue #6 .
We will retry the sending emails when the excption 500 is raised because microsoft api somtimes fails unexpectedly 